### PR TITLE
Remove deprecated methods

### DIFF
--- a/lib/wisper/mongoid/publisher.rb
+++ b/lib/wisper/mongoid/publisher.rb
@@ -12,19 +12,6 @@ module Wisper
         after_destroy    :after_destroy_broadcast, on: :destroy
       end
 
-      def commit(_attributes = nil)
-        warn "[DEPRECATED] use save, create, update_attributes as usual"
-        assign_attributes(_attributes) if _attributes.present?
-        save
-      end
-
-      module ClassMethods
-        def commit(_attributes = nil)
-          warn "[DEPRECATED] use save, create, update_attributes as usual"
-          new(_attributes).save
-        end
-      end
-
       private
 
       def after_validation_broadcast


### PR DESCRIPTION
These methods have never been in the README and it is pre-1.0 so should be fine.
